### PR TITLE
Fix Building For ARM64 Device

### DIFF
--- a/cctools/ar/CMakeLists.txt
+++ b/cctools/ar/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(ar)
 
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
+    add_compile_definitions(__arm64__)
+endif()
+
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../include/foreign)
 

--- a/cctools/ld64/src/CMakeLists.txt
+++ b/cctools/ld64/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(ld64)
 
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
+    add_compile_definitions(__arm64__)
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fblocks -std=c++11 -Wno-long-long -Wno-import -Wno-format -Wno-deprecated -Wno-unused-variable -Wno-unused-private-field -Wno-unused-function -Wno-invalid-offsetof -Wno-int-conversion -Wno-char-subscripts -Wno-shift-negative-value")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/cctools/misc/CMakeLists.txt
+++ b/cctools/misc/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(misc)
 
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
+    add_compile_definitions(__arm64__)
+endif()
+
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../include/foreign)
 


### PR DESCRIPTION
I am currently going through the process of getting Darling to build on my Pinebook Pro. It seems that the `__arm64__`  macro isn't used by either clang or gcc. To avoid breaking anything, I added the `__aarch64__` macro in a OR condition.

This seems to let the program compile without any major issues. The weird thing is that the code in the original repository seems to compile just fine on my machine.

Before I continue to fix the other software, I also want to make sure what I doing is the right way to fix this issue.